### PR TITLE
Added $request to httpClient

### DIFF
--- a/library/ZendService/SlideShare/SlideShare.php
+++ b/library/ZendService/SlideShare/SlideShare.php
@@ -338,7 +338,7 @@ class SlideShare
         $httpClient->setEncType(HttpClient::ENC_URLENCODED);
 
         try {
-            $response = $httpClient->send();
+            $response = $httpClient->send($request);
         } catch(HttpException\ExceptionInterface $e) {
             throw new HttpException\RuntimeException("Service Request Failed: {$e->getMessage()}", 0, $e);
         }
@@ -394,7 +394,7 @@ class SlideShare
             $httpClient->setEncType(HttpClient::ENC_URLENCODED);
 
             try {
-                $response = $httpClient->send();
+                $response = $httpClient->send($request);
             } catch(HttpException\ExceptionInterface $e) {
                 throw new HttpException\RuntimeException("Service Request Failed: {$e->getMessage()}", 0, $e);
             }
@@ -532,7 +532,7 @@ class SlideShare
             $httpClient->setEncType(HttpClient::ENC_URLENCODED);
 
             try {
-                $response = $httpClient->send();
+                $response = $httpClient->send($request);
             } catch(HttpException\ExceptionInterface $e) {
                 throw new HttpException\RuntimeException("Service Request Failed: {$e->getMessage()}", 0, $e);
             }
@@ -597,7 +597,7 @@ class SlideShare
             $httpClient->setEncType(HttpClient::ENC_URLENCODED);
 
             try {
-                $response = $httpClient->send();
+                $response = $httpClient->send($request);
             } catch(HttpException\ExceptionInterface $e) {
                 throw new HttpException\RuntimeException("Service Request Failed: {$e->getMessage()}", 0, $e);
             }


### PR DESCRIPTION
In original code after refactoring it sent an empty request through httpClient it led to infinite error for all API calls.
The issue there is lost $request object as parement in ->send() method
